### PR TITLE
fix script names and typos

### DIFF
--- a/pages/handout/coding-library.mdx
+++ b/pages/handout/coding-library.mdx
@@ -20,7 +20,7 @@ file from your designer, put it as `tokens/design-tokens.json` into
 the repository. Then, build the tokens
 
 ```
-yarn build:tokens
+yarn tokens:build
 ```
 
 This command changes the files in `tokens/dist` directory. Normally, you would
@@ -60,7 +60,7 @@ yarn tokens:version
 
 The release script will build the tokens, increment the version and commit the
 result of the build. If you want to check beforehand that the build is not broken,
-run `build:tokens`.
+run `tokens:build`.
 
 ### Upgrade the tokens version in the library
 
@@ -83,15 +83,15 @@ you can release your library:
 
 
 ```
-yarn version:design-system
+yarn design-system:version
 ```
 
 Similarly to the process with tokens, you will be prompted to type a version.
 Alongside with incrementing the version, this command builds the library and
 commits the result to the repository. If you want to check beforehand that the
-build goes normally, run `yarn build:design-system`.
+build goes normally, run `yarn design-system:build`.
 
-**Now you can use the noew library version in the product.**
+**Now you can use the new library version in the product.**
 
 ### Additional information
 

--- a/pages/handout/inventory.mdx
+++ b/pages/handout/inventory.mdx
@@ -1,9 +1,9 @@
 import Layout from "../../templates/layout"
 
 export default Layout
-export const meta = { title: "UI Invetory" }
+export const meta = { title: "UI Inventory" }
 
-## Download figma file
+## Download Figma file
 Each team can choose one person to own the design file. This person can download 
 [Figma starter file here](https://drive.google.com/file/d/1k8-a0QUtd1qBdThBTtqAcyKZVBqvqcXX/view?usp=sharing)
 
@@ -26,4 +26,4 @@ Once this person downloaded the file and opened it in Figma, this person can sta
 
 
   - Can view: recommend for devs 
-  - Can edit: recommend for Designers 
+  - Can edit: recommend for designers 

--- a/pages/handout/product-release.mdx
+++ b/pages/handout/product-release.mdx
@@ -11,7 +11,7 @@ Make sure your project is built before you release. You can build
 the product with the following command:
 
 ```
-yarn build:product
+yarn product:build
 ```
 
 


### PR DESCRIPTION
Fix script names according latest change, like build:tokens => tokens:build.
Also fixed couple of typos